### PR TITLE
fix: typescript files work without any extra config

### DIFF
--- a/packages/poi-preset-typescript/index.js
+++ b/packages/poi-preset-typescript/index.js
@@ -10,12 +10,12 @@ module.exports = function (options) {
       .test(/\.tsx?$/)
       .use('ts')
         .loader(require.resolve('ts-loader'))
-        .options(options)
+        .options(Object.assign({ appendTsSuffixTo: [/\.vue$/] }, options))
 
-    // Vue support is not working properly now
     config.module.rule('vue')
       .use('vue')
         .tap(vueOptions => {
+          vueOptions.esModule = true
           vueOptions.loaders.ts = [{
             loader: require.resolve('ts-loader'),
             options


### PR DESCRIPTION
This allows typescript to 'just work', without configuration from the user. 

Before in poi.config.js:
```
presets: [
    require('poi-preset-typescript')({
      // options are for ts-loader
        appendTsSuffixTo: [/\.vue$/]
      }),
  ],

    config.module.rule('vue')
      .use('vue')
        .tap(vueOptions => {
          vueOptions.esModule = true;
          return vueOptions;
        });
```
After:
```
presets: [
    require('poi-preset-typescript')(),
  ],
```

They still need a definition file to allow importing .vue files inside of a .ts file though.
**src/sfc.d.ts:**
```
declare module "*.vue" {
  import Vue from 'vue'
  export default typeof Vue
}
```