### PR TITLE
Use compiler.options.devServer if present

### DIFF
--- a/packages/poi/lib/server.js
+++ b/packages/poi/lib/server.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const express = require('express')
+const merge = require('lodash.merge')
 const proxyMiddleware = require('http-proxy-middleware')
 
 module.exports = function (compiler, options = {}) {
@@ -8,11 +9,14 @@ module.exports = function (compiler, options = {}) {
   const port = options.port
   const host = options.host
 
-  const devMiddleWare = require('webpack-dev-middleware')(compiler, {
-    quiet: true,
-    publicPath: compiler.options.output.publicPath,
-    path: `http://${host}:${port}/__webpack_hmr`
-  })
+  const devMiddleWare = require('webpack-dev-middleware')(compiler, merge(
+    compiler.options.devServer || {},
+    {
+      quiet: true,
+      publicPath: compiler.options.output.publicPath,
+      path: `http://${host}:${port}/__webpack_hmr`
+    }
+  ))
 
   server.use(devMiddleWare)
   server.use(require('webpack-hot-middleware')(compiler, {

--- a/packages/poi/lib/server.js
+++ b/packages/poi/lib/server.js
@@ -14,7 +14,7 @@ module.exports = function (compiler, options = {}) {
       publicPath: compiler.options.output.publicPath,
       path: `http://${host}:${port}/__webpack_hmr`
     },
-    options.devMiddleware || {}
+    options.devServer || {}
   ))
 
   server.use(devMiddleWare)

--- a/packages/poi/lib/server.js
+++ b/packages/poi/lib/server.js
@@ -14,7 +14,7 @@ module.exports = function (compiler, options = {}) {
       publicPath: compiler.options.output.publicPath,
       path: `http://${host}:${port}/__webpack_hmr`
     },
-    options.devServer || {}
+    options.devServer || compiler.options.devServer
   ))
 
   server.use(devMiddleWare)

--- a/packages/poi/lib/server.js
+++ b/packages/poi/lib/server.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const express = require('express')
-const merge = require('lodash.merge')
 const proxyMiddleware = require('http-proxy-middleware')
 
 module.exports = function (compiler, options = {}) {
@@ -9,7 +8,7 @@ module.exports = function (compiler, options = {}) {
   const port = options.port
   const host = options.host
 
-  const devMiddleWare = require('webpack-dev-middleware')(compiler, merge(
+  const devMiddleWare = require('webpack-dev-middleware')(compiler, Object.assign(
     options.devMiddleware || {},
     {
       quiet: true,

--- a/packages/poi/lib/server.js
+++ b/packages/poi/lib/server.js
@@ -9,12 +9,12 @@ module.exports = function (compiler, options = {}) {
   const host = options.host
 
   const devMiddleWare = require('webpack-dev-middleware')(compiler, Object.assign(
-    options.devMiddleware || {},
     {
       quiet: true,
       publicPath: compiler.options.output.publicPath,
       path: `http://${host}:${port}/__webpack_hmr`
-    }
+    },
+    options.devMiddleware || {}
   ))
 
   server.use(devMiddleWare)

--- a/packages/poi/lib/server.js
+++ b/packages/poi/lib/server.js
@@ -10,7 +10,7 @@ module.exports = function (compiler, options = {}) {
   const host = options.host
 
   const devMiddleWare = require('webpack-dev-middleware')(compiler, merge(
-    compiler.options.devServer || {},
+    options.devMiddleware || {},
     {
       quiet: true,
       publicPath: compiler.options.output.publicPath,


### PR DESCRIPTION
This is mainly to solve my need of passing the devServer header options to the webpack-dev-middleware instance.