### PR TITLE
Fix issue with process object being clobbered

### DIFF
--- a/packages/poi/lib/create-config.js
+++ b/packages/poi/lib/create-config.js
@@ -214,7 +214,7 @@ module.exports = function ({
 
   config.plugin('constants')
     .use(webpack.DefinePlugin, [merge({
-      'process.env.NODE_ENV': `"${env.NODE_ENV}"`
+      'process.env.NODE_ENV': env.NODE_ENV
     }, define && stringifyObject(define))])
 
   if (format === 'cjs') {

--- a/packages/poi/lib/create-config.js
+++ b/packages/poi/lib/create-config.js
@@ -214,9 +214,7 @@ module.exports = function ({
 
   config.plugin('constants')
     .use(webpack.DefinePlugin, [merge({
-      process: {
-        env
-      }
+      'process.env.NODE_ENV': `"${env.NODE_ENV}"`
     }, define && stringifyObject(define))])
 
   if (format === 'cjs') {

--- a/packages/poi/lib/create-config.js
+++ b/packages/poi/lib/create-config.js
@@ -214,7 +214,7 @@ module.exports = function ({
 
   config.plugin('constants')
     .use(webpack.DefinePlugin, [merge({
-      'process.env.NODE_ENV': env.NODE_ENV
+      'process.env': env
     }, define && stringifyObject(define))])
 
   if (format === 'cjs') {

--- a/packages/poi/package.json
+++ b/packages/poi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poi",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "Fast prototype and distribute modern web apps like a pro.",
   "repository": {
     "url": "egoist/poi",

--- a/packages/poi/package.json
+++ b/packages/poi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poi",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Fast prototype and distribute modern web apps like a pro.",
   "repository": {
     "url": "egoist/poi",

--- a/packages/poi/package.json
+++ b/packages/poi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poi",
-  "version": "9.0.5",
+  "version": "9.0.3",
   "description": "Fast prototype and distribute modern web apps like a pro.",
   "repository": {
     "url": "egoist/poi",


### PR DESCRIPTION
This issue is similar to the one encountered in the below issue.

https://github.com/chentsulin/electron-react-boilerplate/pull/245/files

In my particular case I was depending on a package which was using readable-stream.

https://github.com/nodejs/readable-stream/blob/master/lib/_stream_writable.js#L53

In the above snippet, you can see `process.browser` and `process.version`. When you define process in an object as was done previously it'll actually clobber all the `process` object normalization that webpack does. This means that packages like readable-stream essentially become unusable. 