### PR TITLE
Use default module resolution

### DIFF
--- a/packages/poi/lib/create-config.js
+++ b/packages/poi/lib/create-config.js
@@ -110,7 +110,7 @@ module.exports = function ({
       .add('.vue')
       .end()
     .modules
-      .add(path.resolve('node_modules'))
+      .add('node_modules')
       .add(path.resolve(cwd, 'node_modules'))
       .add(ownDir('node_modules'))
       .end()

--- a/packages/poi/lib/create-config.js
+++ b/packages/poi/lib/create-config.js
@@ -121,7 +121,7 @@ module.exports = function ({
   config.resolveLoader
     .set('symlinks', true)
     .modules
-      .add(path.resolve('node_modules'))
+      .add('node_modules')
       .add(path.resolve(cwd, 'node_modules'))
       .add(ownDir('node_modules'))
 


### PR DESCRIPTION
Actually, you're overriding the default module resolution by not passing a relative 'node_modules' path.

This causes problems, for example, when you use `npm link` or `yarn link`. Packages won't be discovered for the linked modules.

This fixes it.