### PR TITLE
Allow proxy shorthand other than '/api'

### DIFF
--- a/packages/poi/lib/server.js
+++ b/packages/poi/lib/server.js
@@ -14,12 +14,13 @@ module.exports = function (compiler, options) {
   }, compiler.options.devServer, options.devServer)
 
   if (typeof devServerOptions.proxy === 'string') {
+    const proxyUrl = require('url').parse(devServerOptions.proxy)
     devServerOptions.proxy = {
-      '/api': {
+      [proxyUrl.path]: {
         target: devServerOptions.proxy,
         changeOrigin: true,
         pathRewrite: {
-          '^/api': ''
+          ['^' + proxyUrl.path]: ''
         }
       }
     }


### PR DESCRIPTION
Hey,
I think the docs about [proxying api requests](https://poi.js.org/#/home?id=proxy-api-request) are a bit misleading. They suggest a shorthand declaration as in [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware#shorthand) is possible. But no matter what URL is supplied it always proxies `/api`.

This little change actually allows this shorthand for URL.