### PR TITLE
karma-preset: Invalid path when using objects in files

### DIFF
--- a/packages/poi-preset-karma/index.js
+++ b/packages/poi-preset-karma/index.js
@@ -57,7 +57,11 @@ module.exports = (options = {}) => {
           }]
         },
         preprocessors: files.reduce((current, next) => {
-          current[next] = ['webpack', 'sourcemap']
+          if (typeof next === 'object' && next.included !== false) {
+            current[next.pattern] = ['webpack', 'sourcemap']
+          } else if (typeof next === 'string') {
+            current[next] = ['webpack', 'sourcemap']
+          }
           return current
         }, {}),
         webpackMiddleware: {


### PR DESCRIPTION
With a files config like this:

```
files: [
  'test/*.test.js',
  {pattern: 'test/*.m??', watched: false, included: false, served: true, nocache: false},
]
```

You would end up with a preprocessor array like this (see the 2nd key):

```
  preprocessors:
   { 'test/*.test.js': [ 'webpack', 'sourcemap' ],
     '[object Object]': [ 'webpack', 'sourcemap' ] },
```

This PR checks type and if object only includes if `included: false` (or absent)