### PR TITLE
fix bug in preset-transform-test-files

### DIFF
--- a/packages/poi-preset-transform-test-files/index.js
+++ b/packages/poi-preset-transform-test-files/index.js
@@ -15,7 +15,7 @@ module.exports = () => {
 
     poi.run('test', webpackConfig => {
       const input = poi.argv._.slice(1)
-      const inputFiles = input > 0 ? input : ['**/*.test.js']
+      const inputFiles = input.length > 0 ? input : ['**/*.test.js']
       const ignores = ['!**/node_modules/**', '!**/vendor/**']
 
       return globby(inputFiles.concat(ignores), { cwd: poi.options.cwd })


### PR DESCRIPTION
On line 18, `input` is an array and so `input > 0` is always false. The fix checks the array length.