### PR TITLE
fix: make babel minify preset respect `minimize` option

### DIFF
--- a/packages/poi-preset-babel-minify/index.js
+++ b/packages/poi-preset-babel-minify/index.js
@@ -4,8 +4,11 @@ module.exports = (pluginOptions, overrides) => {
       // Say goodbye to uglify plugin
       const BabelMinifyPlugin = require('babel-minify-webpack-plugin')
 
-      config.plugin('minimize')
-        .use(BabelMinifyPlugin, [pluginOptions, overrides])
+      // do not use if `minimize` is off
+      if (config.plugins.has('minimize')) {
+        config.plugin('minimize')
+          .use(BabelMinifyPlugin, [pluginOptions, overrides])
+      }
     })
   }
 }


### PR DESCRIPTION
The babel-minify-preset always gets used, even when the `minimize` option is set to false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/egoist/poi/256)
<!-- Reviewable:end -->
