### PR TITLE
feat: poi-preset-karma supports TypeScript

### DIFF
--- a/packages/poi-preset-karma/README.md
+++ b/packages/poi-preset-karma/README.md
@@ -125,3 +125,22 @@ module.exports = {
   }
 }
 ```
+
+### TypeScript support
+
+It works with [poi-preset-typescript](https://github.com/egoist/poi/tree/master/packages/poi-preset-typescript).
+
+```js
+// poi.config.js
+module.exports = {
+  presets: [
+    // The order matters!
+    require('poi-preset-typescript')(),
+    require('poi-preset-karma')()
+  ]
+}
+```
+
+## License
+
+MIT &copy; [EGOIST](https://github.com/egoist)

--- a/packages/poi-preset-karma/package.json
+++ b/packages/poi-preset-karma/package.json
@@ -16,6 +16,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.4",
     "karma-sourcemap-loader": "^0.3.7",
+    "karma-typescript": "^3.0.8",
     "karma-webpack": "^2.0.4",
     "mocha": "^3.5.0"
   },


### PR DESCRIPTION
Include the preset `poi-preset-typescript` _before_ this preset,
for example:

```
module.exports = {
  presets: [
    require('poi-preset-typescript')(),
    require('poi-preset-karma')()
  ]
}
```