### PR TITLE
fix: Fixes preprocessors keys for when included === false

### DIFF
--- a/packages/poi-preset-karma/index.js
+++ b/packages/poi-preset-karma/index.js
@@ -97,7 +97,10 @@ module.exports = (options = {}) => {
           ]
         },
         preprocessors: files.reduce((current, next) => {
-          const key = typeof next === 'object' && next.included !== false ? next.pattern : next
+          if (typeof next === 'object' && next.included === false) {
+            return current
+          }
+          const key = next.pattern || next
           current[key] = ['webpack', ...(isTypeScript ? ['karma-typescript'] : [])]
           return current
         }, {}),


### PR DESCRIPTION
The previous fix missed that when false it shouldn't create a key at all
so it ended up with a key named `[object Object]` nonetheless.