### PR TITLE
make karma-typescript optional

### DIFF
--- a/packages/poi-preset-karma/README.md
+++ b/packages/poi-preset-karma/README.md
@@ -130,6 +130,8 @@ module.exports = {
 
 It works with [poi-preset-typescript](https://github.com/egoist/poi/tree/master/packages/poi-preset-typescript).
 
+You need to install `karma-typescript` and `typescript` locally in your project first, and configure `poi-preset-typescript`:
+
 ```js
 // poi.config.js
 module.exports = {

--- a/packages/poi-preset-karma/package.json
+++ b/packages/poi-preset-karma/package.json
@@ -16,7 +16,6 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.4",
     "karma-sourcemap-loader": "^0.3.7",
-    "karma-typescript": "^3.0.8",
     "karma-webpack": "^2.0.4",
     "mocha": "^3.5.0"
   },


### PR DESCRIPTION
Karma by default loads all plugins starting with `karma- *`. This fix prevents the need to configure typescript in projects that do not use it.