### PR TITLE
Support multi entries in poi-preset-transform-test-files

### DIFF
--- a/packages/poi-preset-transform-test-files/example/another.test.js
+++ b/packages/poi-preset-transform-test-files/example/another.test.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import fn from './'
 
-test('main', t => {
-  t.is(fn(), 43)
+test('another', t => {
+  t.snapshot(fn())
 })

--- a/packages/poi-preset-transform-test-files/example/deep/yet-another.test.js
+++ b/packages/poi-preset-transform-test-files/example/deep/yet-another.test.js
@@ -1,6 +1,6 @@
 import test from 'ava'
-import fn from './'
+import fn from '../'
 
 test('main', t => {
-  t.is(fn(), 43)
+  t.is(fn(), 42)
 })

--- a/packages/poi-preset-transform-test-files/index.js
+++ b/packages/poi-preset-transform-test-files/index.js
@@ -26,7 +26,6 @@ module.exports = () => {
             res[filename.replace(/\.[a-z]{2,}$/, '')] = path.resolve(baseDir, filename)
             return res
           }, {})
-          console.log(webpackConfig.entry)
         })
         .then(() => poi.runWebpack(webpack(webpackConfig)))
     })

--- a/packages/poi-preset-transform-test-files/index.js
+++ b/packages/poi-preset-transform-test-files/index.js
@@ -14,15 +14,19 @@ module.exports = () => {
     })
 
     poi.run('test', webpackConfig => {
+      const baseDir = poi.argv.baseDir || './test'
       const input = poi.argv._.slice(1)
-      const inputFiles = input.length > 0 ? input : ['**/*.test.js']
+      const inputFiles = input.length > 0 ? input : ['**/*.{test,spec}.js']
       const ignores = ['!**/node_modules/**', '!**/vendor/**']
 
-      return globby(inputFiles.concat(ignores), { cwd: poi.options.cwd })
+      return globby(inputFiles.concat(ignores), { cwd: baseDir })
         .then(files => {
           delete webpackConfig.entry.client
-          webpackConfig.entry.test = files
-            .map(file => path.resolve(poi.options.cwd, file))
+          webpackConfig.entry = files.reduce((res, filename) => {
+            res[filename.replace(/\.[a-z]{2,}$/, '')] = path.resolve(baseDir, filename)
+            return res
+          }, {})
+          console.log(webpackConfig.entry)
         })
         .then(() => poi.runWebpack(webpack(webpackConfig)))
     })

--- a/packages/poi-preset-transform-test-files/package.json
+++ b/packages/poi-preset-transform-test-files/package.json
@@ -7,10 +7,6 @@
   "files": [
     "index.js"
   ],
-  "scripts": {
-    "ava": "poi test && ava output_test/test.js",
-    "jest": "poi test && jest output_test/test.js"
-  },
   "poi": {
     "presets": "./index.js"
   },
@@ -18,7 +14,7 @@
     "globby": "^6.1.0"
   },
   "devDependencies": {
-    "ava": "^0.19.1",
+    "ava": "^0.24.0",
     "jest": "^20.0.0",
     "webpack": "^2.6.1"
   },


### PR DESCRIPTION
Bug:

- AVA snapshots are generated to a weird directory (should have been `output_test/snapshots`)

![2017-12-15 1 47 12](https://user-images.githubusercontent.com/8784712/34028503-8e949a7e-e19e-11e7-9855-ca89859f48c6.png)
