### PR TITLE
fix babel 7 babelrc validate failed

### DIFF
--- a/packages/poi/lib/handle-options.js
+++ b/packages/poi/lib/handle-options.js
@@ -52,7 +52,6 @@ module.exports = co.wrap(function * (options) {
       console.log(
         chalk.dim(`> location: "${tildify(externalBabelConfig.loc)}"`)
       )
-      options.babel.babelrc = externalBabelConfig.options.babelrc !== false
     } else {
       options.babel.babelrc = false
     }

--- a/packages/poi/package.json
+++ b/packages/poi/package.json
@@ -92,7 +92,6 @@
     "yarn-global": "^1.1.0"
   },
   "babel": {
-    "babelrc": false,
     "env": {
       "test": {
         "presets": [


### PR DESCRIPTION
babelrc validate failed in dev mode adding `app/dev-client.es6` into entry
![deepinscreenshot_select-area_20180108182033](https://user-images.githubusercontent.com/2224764/34667006-0daba5c6-f4a2-11e7-9718-8f5d591e2912.png)
