### PR TITLE
Add markdown support on poi-preset-storybook

### DIFF
--- a/packages/poi-preset-storybook/README.md
+++ b/packages/poi-preset-storybook/README.md
@@ -84,6 +84,22 @@ Here's the source code of [a complete example](https://github.com/poi-examples/s
 
 > **Note**: [`templateCompiler`](https://poi.js.org/#/options?id=templatecompiler) is `true` by default in `--storybook` mode.
 
+### Using markdown file
+
+You can import `.md` files and they will be parsed by `markdown-loader` using `marked`, however you might want to use your own loader to parse markdown files:
+
+```js
+// poi.config.js
+module.exports = {
+  extendWebpack(config) {
+    config.module.rule('markdown')
+      .use('markdown')
+        .loader('markdown-it-loader') // Use markdown-it instead
+        .options(/* maybe some options */)
+  }
+}
+```
+
 ## Options
 
 ### managerTemplate

--- a/packages/poi-preset-storybook/README.md
+++ b/packages/poi-preset-storybook/README.md
@@ -116,6 +116,13 @@ Default: [`./lib/iframe.ejs`](./lib/iframe.ejs)
 
 Path to the HTML template for generated `iframe.html`.
 
+### markdown
+
+Type: `boolean`<br>
+Default: `undefined`
+
+Whether to support `.md` files or not.
+
 ## Gotchas
 
 [Vue-devtools does not work for now](https://github.com/storybooks/storybook/issues/1708).

--- a/packages/poi-preset-storybook/lib/index.js
+++ b/packages/poi-preset-storybook/lib/index.js
@@ -52,7 +52,7 @@ module.exports = ({
         test: /\.md$/,
         use: [
           {
-            loader: 'raw-loader'
+            loader: 'html-loader'
           },
           {
             loader: 'markdown-loader'

--- a/packages/poi-preset-storybook/lib/index.js
+++ b/packages/poi-preset-storybook/lib/index.js
@@ -46,6 +46,19 @@ module.exports = ({
       '@storybook/vue/dist/client/manager',
       '@storybook/react/dist/client/manager'
     ]))
+
+    config.module
+      .rule('markdown').merge({
+        test: /\.md$/,
+        use: [
+          {
+            loader: 'raw-loader'
+          },
+          {
+            loader: 'markdown-loader'
+          }
+        ]
+      })
   })
 }
 

--- a/packages/poi-preset-storybook/lib/index.js
+++ b/packages/poi-preset-storybook/lib/index.js
@@ -2,7 +2,8 @@ const path = require('path')
 
 module.exports = ({
   managerTemplate = path.join(__dirname, 'manager.ejs'),
-  iframeTemplate = path.join(__dirname, 'iframe.ejs')
+  iframeTemplate = path.join(__dirname, 'iframe.ejs'),
+  markdown: useMarkdown
 } = {}) => poi => {
   if (!poi.argv.storybook) return
 
@@ -47,15 +48,17 @@ module.exports = ({
       '@storybook/react/dist/client/manager'
     ]))
 
-    config.module
-      .rule('markdown')
-        .test(/\.md$/)
-        .use('html')
-          .loader('html-loader')
-          .end()
-        .use('markdown')
-          .loader('markdown-loader')
-          .end()
+    if (useMarkdown !== false) {
+      config.module
+        .rule('markdown')
+          .test(/\.md$/)
+          .use('html')
+            .loader('html-loader')
+            .end()
+          .use('markdown')
+            .loader('markdown-loader')
+            .end()
+    }
   })
 }
 

--- a/packages/poi-preset-storybook/lib/index.js
+++ b/packages/poi-preset-storybook/lib/index.js
@@ -48,17 +48,14 @@ module.exports = ({
     ]))
 
     config.module
-      .rule('markdown').merge({
-        test: /\.md$/,
-        use: [
-          {
-            loader: 'html-loader'
-          },
-          {
-            loader: 'markdown-loader'
-          }
-        ]
-      })
+      .rule('markdown')
+        .test(/\.md$/)
+        .use('html')
+          .loader('html-loader')
+          .end()
+        .use('markdown')
+          .loader('markdown-loader')
+          .end()
   })
 }
 

--- a/packages/poi-preset-storybook/package.json
+++ b/packages/poi-preset-storybook/package.json
@@ -13,7 +13,7 @@
     "example-react:build": "poi build --config example-react/poi.config.js --storybook"
   },
   "license": "MIT",
-  "peerDependencies": {
+  "dependencies": {
     "html-loader": "^0.5.5",
     "markdown-loader": "^2.0.2"
   },

--- a/packages/poi-preset-storybook/package.json
+++ b/packages/poi-preset-storybook/package.json
@@ -13,6 +13,10 @@
     "example-react:build": "poi build --config example-react/poi.config.js --storybook"
   },
   "license": "MIT",
+  "peerDependencies": {
+    "html-loader": "^0.5.5",
+    "markdown-loader": "^2.0.2"
+  },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.13",
     "poi-preset-react": "^9.2.1",


### PR DESCRIPTION
For keeping it on track with latest default storybook config.

- [default loader](https://github.com/storybooks/storybook/blob/master/app/vue/src/server/config/webpack.config.js#L53)
- [genDefaultConfig](https://github.com/storybooks/storybook/blob/master/app/vue/src/server/config/defaults/webpack.config.js) stated in [here](https://storybook.js.org/configurations/custom-webpack-config/#full-control-mode--default)

> Related to [!2](https://github.com/DrSensor/vue-authoring-template/issues/2).
Although its `webpack-chain` responsibility for documenting [`webpack.config.js` to `webpack-chain`](https://github.com/mozilla-neutrino/webpack-chain/issues/6#issuecomment-283851444) recipe. I think it would be nice if poi provides this to in the documentation.