### PR TITLE
Support customized name for 'vendor', 'manifest' and 'client'

### DIFF
--- a/packages/poi/lib/create-config.js
+++ b/packages/poi/lib/create-config.js
@@ -88,9 +88,9 @@ module.exports = function ({
   }
 
   if (typeof entry === 'string') {
-    config.entry('client').add(handleEntryPath(entry))
+    config.entry(filename.client).add(handleEntryPath(entry))
   } else if (Array.isArray(entry)) {
-    config.entry('client').merge(entry.map(e => handleEntryPath(e)))
+    config.entry(filename.client).merge(entry.map(e => handleEntryPath(e)))
   } else if (typeof entry === 'object') {
     Object.keys(entry).forEach(k => {
       const v = entry[k]
@@ -283,14 +283,14 @@ module.exports = function ({
   if (vendor && !format && mode !== 'test') {
     config.plugin('split-vendor-code')
       .use(webpack.optimize.CommonsChunkPlugin, [{
-        name: 'vendor',
+        name: filename.vendor,
         minChunks: module => {
           return module.context && module.context.indexOf('node_modules') >= 0
         }
       }])
     config.plugin('split-manifest')
       .use(webpack.optimize.CommonsChunkPlugin, [{
-        name: 'manifest'
+        name: filename.manifest
       }])
   }
 

--- a/packages/poi/lib/handle-options.js
+++ b/packages/poi/lib/handle-options.js
@@ -6,13 +6,7 @@ const tildify = require('tildify')
 const kebabCase = require('lodash/kebabCase')
 const buildConfigChain = require('babel-core/lib/transformation/file/options/build-config-chain')
 
-const { inferHTML, readPkg } = require('./utils')
-
-function getLibraryFilename(component) {
-  return kebabCase(
-    typeof component === 'string' ? component : path.basename(process.cwd())
-  )
-}
+const { inferHTML, readPkg, getLibraryFilename } = require('./utils')
 
 module.exports = co.wrap(function * (options) {
   const loadExternalConfig = new LoadExternalConfig({ cwd: options.cwd })

--- a/packages/poi/lib/handle-options.js
+++ b/packages/poi/lib/handle-options.js
@@ -1,9 +1,7 @@
-const path = require('path')
 const co = require('co')
 const chalk = require('chalk')
 const LoadExternalConfig = require('poi-load-config')
 const tildify = require('tildify')
-const kebabCase = require('lodash/kebabCase')
 const buildConfigChain = require('babel-core/lib/transformation/file/options/build-config-chain')
 
 const { inferHTML, readPkg, getLibraryFilename } = require('./utils')

--- a/packages/poi/lib/utils.js
+++ b/packages/poi/lib/utils.js
@@ -54,14 +54,35 @@ exports.inferHTML = function (options) {
   return result
 }
 
+exports.getLibraryFilename = function (library) {
+  return kebabCase(
+    typeof library === 'string' ? library : path.basename(process.cwd())
+  )
+}
+
 exports.getFileNames = function (useHash, customFileName) {
-  return Object.assign({
+  const filenames = Object.assign({
     js: useHash ? '[name].[chunkhash:8].js' : '[name].js',
     css: useHash ? '[name].[contenthash:8].css' : '[name].css',
     images: 'assets/images/[name].[hash:8].[ext]',
     fonts: useHash ? 'assets/fonts/[name].[hash:8].[ext]' : 'assets/fonts/[name].[ext]',
-    chunk: useHash ? '[name].[chunkhash:8].chunk.js' : '[name].chunk.js'
+    chunk: useHash ? '[name].[chunkhash:8].chunk.js' : '[name].chunk.js',
+    vendor: 'vendor',
+    manifest: 'manifest',
+    client: 'client'
   }, customFileName)
+
+  const pkg = exports.readPkg()
+  const pkgName = pkg ? pkg.name : getLibraryFilename()
+  const normalizeName = name => name
+    .replace('[name]', pkgName)
+    .replace('.js', '')
+
+  filenames.vendor = normalizeName(filenames.vendor)
+  filenames.manifest = normalizeName(filenames.manifest)
+  filenames.client = normalizeName(filenames.client)
+
+  return filenames
 }
 
 exports.inferProductionValue = function (value, mode) {

--- a/packages/poi/lib/utils.js
+++ b/packages/poi/lib/utils.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const chalk = require('chalk')
 const tildify = require('tildify')
+const kebabCase = require('lodash/kebabCase')
 const AppError = require('./app-error')
 
 exports.cwd = function (cwd, ...args) {
@@ -73,7 +74,7 @@ exports.getFileNames = function (useHash, customFileName) {
   }, customFileName)
 
   const pkg = exports.readPkg()
-  const pkgName = pkg ? pkg.name : getLibraryFilename()
+  const pkgName = pkg ? pkg.name : exports.getLibraryFilename()
   const normalizeName = name => name
     .replace('[name]', pkgName)
     .replace('.js', '')


### PR DESCRIPTION
Now, If you are bundling you app that depends on third-party libraries by poi, you can customize the names of 'vendor', 'manifest' and 'client' file.

And '[name]' is the shortcut of the name in 'package.json'. if not found name in package.json, fallbacks to current folder name in kebab case.