### PR TITLE
Fix Windows transformModules path separator bug

### DIFF
--- a/packages/poi/lib/webpack/transform-js.js
+++ b/packages/poi/lib/webpack/transform-js.js
@@ -12,13 +12,13 @@ module.exports = (config, { babel, transformModules }) => {
       .include
       .add(filepath => {
         // For anything outside node_modules
-        if (filepath.indexOf(`${path.sep}node_modules${path.sep}`) === -1) {
+        if (filepath.indexOf(path.normalize('/node_modules/')) === -1) {
           return true
         }
         // For specified modules
         if (Array.isArray(transformModules)) {
           const hasModuleToTransform = transformModules.some(name => {
-            return filepath.indexOf(`${path.sep}node_modules${path.sep}${name}${path.sep}`) >= 0
+            return filepath.indexOf(path.normalize(`/node_modules/${name}/`)) >= 0
           })
           if (hasModuleToTransform) {
             return true


### PR DESCRIPTION
Instead of using `path.sep`, we can use `path.normalize` to ensure the appropriate path separator is used in all situations.

Specifically, this fixes the case when we have a module we want to transform, but its name contains a forward slash (e.g `@company/package`). Using `path.sep`, we were ending up with a path that looked something like `\node_modules\@company/package\`. This doesn't match against the `filepath` variable we are testing against on Windows which only contains backslashes.