### PR TITLE
Add poi-preset-reasonml

### DIFF
--- a/packages/poi-preset-reasonml/.gitignore
+++ b/packages/poi-preset-reasonml/.gitignore
@@ -1,0 +1,4 @@
+# bucklescript
+lib
+types
+.merlin

--- a/packages/poi-preset-reasonml/README.md
+++ b/packages/poi-preset-reasonml/README.md
@@ -1,0 +1,31 @@
+# poi-preset-reasonml
+
+Use ReasonML in your Poi project.
+
+## Install
+
+```bash
+yarn add poi-preset-reasonml --dev
+```
+
+## Usage
+
+```js
+// poi.config.js
+module.exports = {
+  presets: [
+    require('poi-preset-reasonml')(options)
+  ]
+}
+```
+
+## Options
+
+### loaderOptions
+
+Type: `object`<br>
+[options](https://github.com/reasonml-community/bs-loader#options) for bs-loader
+
+## License
+
+MIT © [EGOIST](https://github.com/egoist)

--- a/packages/poi-preset-reasonml/example/bsconfig.json
+++ b/packages/poi-preset-reasonml/example/bsconfig.json
@@ -1,0 +1,16 @@
+{
+  "name": "example",
+  "sources": [{
+    "dir": "."
+  }],
+  "bsc-flags": [
+    "-bs-super-errors"
+  ],
+  "reason": {},
+  "refmt": 3,
+  "package-specs": [{
+    "module": "es6",
+    "in-source": false
+  }],
+  "suffix": ".bs.js"
+}

--- a/packages/poi-preset-reasonml/example/index.js
+++ b/packages/poi-preset-reasonml/example/index.js
@@ -1,0 +1,3 @@
+import { add } from './math_fns.re';
+
+add(1, 2);

--- a/packages/poi-preset-reasonml/example/math_fns.re
+++ b/packages/poi-preset-reasonml/example/math_fns.re
@@ -1,0 +1,1 @@
+let add = (x, y) => x + y;

--- a/packages/poi-preset-reasonml/index.js
+++ b/packages/poi-preset-reasonml/index.js
@@ -1,0 +1,21 @@
+/**
+ * Add ReasonML support
+ * @name presetReasonML
+ * @param {Object} options
+ * @param {any} [options.loaderOptions=undefined] - Options for bs-loader.
+ */
+module.exports = ({ loaderOptions } = {}) => {
+  return poi => {
+    poi.extendWebpack(config => {
+      config.resolve.extensions
+        .add('.re')
+        .add('.ml')
+
+      config.module.rule('reasonml')
+        .test(/\.(re|ml)$/)
+        .use('bs-loader')
+          .loader('bs-loader')
+          .options(loaderOptions)
+    })
+  }
+}

--- a/packages/poi-preset-reasonml/index.js
+++ b/packages/poi-preset-reasonml/index.js
@@ -11,11 +11,17 @@ module.exports = ({ loaderOptions } = {}) => {
         .add('.re')
         .add('.ml')
 
-      config.module.rule('reasonml')
-        .test(/\.(re|ml)$/)
-        .use('bs-loader')
-          .loader('bs-loader')
-          .options(loaderOptions)
+      config.module
+        .rule('reasonml')
+          .test(/\.(re|ml)$/)
+          .exclude
+            .add(/node_modules/)
+            .end()
+          .use('bs-loader')
+            .loader('bs-loader')
+            .options(loaderOptions)
+            .end()
+          .end()
     })
   }
 }

--- a/packages/poi-preset-reasonml/package.json
+++ b/packages/poi-preset-reasonml/package.json
@@ -3,12 +3,14 @@
   "version": "1.0.0",
   "description": "Use ReasonML in your Poi project",
   "files": [
-    "index.js"
+    "index.js",
+    "postinstall.js"
   ],
   "scripts": {
     "test": "echo fine",
     "example": "cd example && poi index.js --presets ../index.js",
-    "example:build": "cd example && poi build index.js --presets ../index.js"
+    "example:build": "cd example && poi build index.js --presets ../index.js",
+    "postinstall": "./postinstall.js"
   },
   "license": "MIT",
   "author": {

--- a/packages/poi-preset-reasonml/package.json
+++ b/packages/poi-preset-reasonml/package.json
@@ -17,7 +17,7 @@
     "name": "EGOIST",
     "email": "0x142857@gmail.com"
   },
-  "devDependencies": {
+  "dependencies": {
     "bs-loader": "^2.0.1",
     "bs-platform": "^2.2.2"
   }

--- a/packages/poi-preset-reasonml/package.json
+++ b/packages/poi-preset-reasonml/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "poi-preset-reasonml",
+  "version": "1.0.0",
+  "description": "Use ReasonML in your Poi project",
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "test": "echo fine",
+    "example": "cd example && poi index.js --presets ../index.js",
+    "example:build": "cd example && poi build index.js --presets ../index.js"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "EGOIST",
+    "email": "0x142857@gmail.com"
+  },
+  "devDependencies": {
+    "bs-loader": "^2.0.1",
+    "bs-platform": "^2.2.2"
+  }
+}

--- a/packages/poi-preset-reasonml/postinstall.js
+++ b/packages/poi-preset-reasonml/postinstall.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+// dirty hack to get out of `node_modules` dir
+const pjDir = path.join(path.resolve('..', '..'))
+const fPath = path.join(pjDir, 'bsconfig.json')
+
+// default bsconfig.json content
+const defaultConfig = {
+  name: `${path.basename(pjDir)}`,
+  sources: [
+    {
+      dir: 'src'
+    }
+  ],
+  'bsc-flags': ['-bs-super-errors'],
+  reason: {},
+  refmt: 3,
+  'package-specs': [
+    {
+      module: 'es6',
+      'in-source': false
+    }
+  ],
+  suffix: '.bs.js'
+}
+
+// write bsconfig.json if not exist
+if (!fs.existsSync(fPath)) {
+  fs.writeFile(fPath, JSON.stringify(defaultConfig, null, 2), err => {
+    if (err) {
+      console.log(err)
+      process.exit(1)
+    }
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,6 +2154,22 @@ browserslist@^2.1.2, browserslist@^2.10.2:
     caniuse-lite "^1.0.30000789"
     electron-to-chromium "^1.3.30"
 
+bs-loader@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/bs-loader/-/bs-loader-2.0.1.tgz#e72e3cf0f00f0f41affbf51e34860d1212692b6d"
+  dependencies:
+    bsb-js "^1.0.0"
+    loader-utils "^1.1.0"
+    read-bsconfig "^1.0.1"
+
+bs-platform@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.2.tgz#95ff37719771bbf310e8376fedd1148865c0da19"
+
+bsb-js@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bsb-js/-/bsb-js-1.0.2.tgz#b9e7af1dfdb8de6191bb36fdff43f59359a7dfe7"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -9738,6 +9754,12 @@ read-all-stream@^3.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
     readable-stream "^2.0.0"
+
+read-bsconfig@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/read-bsconfig/-/read-bsconfig-1.0.4.tgz#3dabf6b1c08451a6939274cb5e178733bcbb1bdf"
+  dependencies:
+    json5 "^0.5.1"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
fix #275 

Currently I have no idea how to properly add `bsconfig.json` to user's dir with `postinstall` hook, tried it and bsconfig got cretead inside `node_modules` dir instead. Please let me know and I'll update the PR, thanks.