### PR TITLE
fix: Fix wrong error message trim

### DIFF
--- a/packages/friendly-webpack-reporter/lib/transformer.js
+++ b/packages/friendly-webpack-reporter/lib/transformer.js
@@ -6,6 +6,12 @@ function isFile(file) {
 }
 
 module.exports = error => {
+  if (typeof error === 'string') {
+    error = {
+      message: error
+    }
+  }
+
   // Errors thrown by @poi/bs-loader etc
   if (
     error.name === 'ModuleBuildError' &&


### PR DESCRIPTION
Sometimes, thrown `error` is not an `Error Object`, but `string`.