### PR TITLE
Fix storybook plugin

### DIFF
--- a/packages/plugin-storybook/lib/index.js
+++ b/packages/plugin-storybook/lib/index.js
@@ -47,8 +47,8 @@ module.exports = ({
             getManager([
               'storybook-vue/lib/manager',
               'storybook-react/lib/manager',
-              '@storybook/vue/dist/client/manager',
-              '@storybook/react/dist/client/manager'
+              '@storybook/vue/dist/client',
+              '@storybook/react/dist/client'
             ])
           )
 


### PR DESCRIPTION
Fix #413 

<img width="211" alt="screen shot 2018-05-23 at 4 22 21 pm" src="https://user-images.githubusercontent.com/9855651/40412487-08652de4-5ea6-11e8-99e3-0583dcdad5c2.png">

It looks like they have changed their diet directory structure.