### PR TITLE
Use URL of script instead of window.location for dev server

### DIFF
--- a/packages/dev-utils/hotDevClient.js
+++ b/packages/dev-utils/hotDevClient.js
@@ -57,12 +57,32 @@ if (module.hot && typeof module.hot.dispose === 'function') {
   })
 }
 
+function getCurrentScriptSource() {
+  // `document.currentScript` is the most accurate way to find the current script,
+  // but is not supported in all browsers.
+  if (document.currentScript) {
+    return document.currentScript.getAttribute('src');
+  }
+  // Fall back to getting all scripts in the document.
+  var scriptElements = document.scripts || [];
+  var currentScript = scriptElements[scriptElements.length - 1];
+  if (currentScript) {
+    return currentScript.getAttribute('src');
+  }
+  // Fail as there was no script to use.
+  throw new Error('[WDS] Failed to get current script source.');
+}
+
+var scriptHost = getCurrentScriptSource();
+scriptHost = scriptHost.replace(/\/[^\/]+$/, '');
+urlParts = url.parse(scriptHost || '/', false, true);
+
 // Connect to WebpackDevServer via a socket.
 var connection = new SockJS(
   url.format({
-    protocol: window.location.protocol,
-    hostname: window.location.hostname,
-    port: window.location.port,
+    protocol: urlParts.protocol,
+    hostname: urlParts.hostname,
+    port: urlParts.port,
     // Hardcoded in WebpackDevServer
     pathname: '/sockjs-node'
   })


### PR DESCRIPTION
In my scenario, the page is being served by PHP and the URL to the bundle is pointed directly to the webpack dev server.

So, the website is being served at http://my-project.test and the script is pointing to http://localhost:8080/app.js.

By using window.location for the webpack dev server client, it is forcing the sockjs server to be on the same domain as the page. However, it's more accurate to get the dev server from the script.

References: 

* https://github.com/vuejs/vue-cli/pull/1421
* https://github.com/vuejs/vue-cli/issues/1390
* https://github.com/morrislaptop/VueServeValetDriver