### PR TITLE
Use configured publicPath in watch

### DIFF
--- a/packages/poi/lib/utils/getPublicPath.js
+++ b/packages/poi/lib/utils/getPublicPath.js
@@ -1,5 +1,5 @@
 function getPublicPath(command, publicPath) {
-  if (command === 'build' && typeof publicPath === 'string') {
+  if (['build', 'watch'].includes(command) && typeof publicPath === 'string') {
     return /\/$/.test(publicPath) || publicPath === ''
       ? publicPath
       : publicPath + '/'


### PR DESCRIPTION
This PR updates the `getPublicPath` utility to return the configured `publicPath` during `watch` mode as well as the currently configured `build` mode.

My assumption on why `getPublicPath` exists is that when using the dev server via `poi develop`, assets are usually served from `/` instead of the configured asset path. For this reason, I have kept the `develop` command excluded from the list.

For anyone wishing to override the `publicPath` across all commands, they can use the `chainWebpack` hook to force update the configuration.

```js
chainWebpack(config, context) {
  config.output.publicPath("/assets/");
}
```

This PR should somewhat resolve #460.