### PR TITLE
Improve devServer config validation

### DIFF
--- a/core/poi/lib/utils/validateConfig.js
+++ b/core/poi/lib/utils/validateConfig.js
@@ -85,7 +85,7 @@ module.exports = (api, config) => {
           struct([struct.union(['object', 'function'])])
         ])
       ),
-      open: struct.union(['boolean', 'string']),
+      open: 'boolean',
       historyApiFallback: struct.optional(struct.union(['boolean', 'object'])),
       before: struct.optional('function'),
       after: struct.optional('function'),

--- a/core/poi/lib/utils/validateConfig.js
+++ b/core/poi/lib/utils/validateConfig.js
@@ -73,6 +73,7 @@ module.exports = (api, config) => {
   const devServer = struct(
     {
       hot: 'boolean',
+      hotOnly: 'boolean?',
       host: 'string',
       port: struct.union(['string', 'number']),
       hotEntries: struct(['string']),
@@ -84,7 +85,8 @@ module.exports = (api, config) => {
           struct([struct.union(['object', 'function'])])
         ])
       ),
-      open: 'boolean',
+      open: struct.union(['boolean', 'string']),
+      historyApiFallback: struct.optional(struct.union(['boolean', 'object'])),
       before: struct.optional('function'),
       after: struct.optional('function'),
       https: struct.optional(struct.union(['boolean', 'object']))

--- a/core/poi/lib/utils/validateConfig.js
+++ b/core/poi/lib/utils/validateConfig.js
@@ -75,7 +75,7 @@ module.exports = (api, config) => {
       hot: 'boolean',
       host: 'string',
       port: struct.union(['string', 'number']),
-      hotEntries: struct.tuple(['string']),
+      hotEntries: struct(['string']),
       proxy: struct.optional(
         struct.union([
           'string',


### PR DESCRIPTION
- Allowed `devServer.hotEntries` to be a list of varying length
- Added `historyApiFallback` to enable custom routing for single-page apps
- Changed `open` to allow strings, as is allowed by `webpack-dev-server`