### PR TITLE
Validate devServer.headers option

### DIFF
--- a/core/poi/lib/utils/validateConfig.js
+++ b/core/poi/lib/utils/validateConfig.js
@@ -84,6 +84,7 @@ module.exports = (api, config) => {
       host: 'string',
       port: struct.union(['string', 'number']),
       hotEntries: struct(['string']),
+      headers: struct.optional('object'),
       proxy: struct.optional(
         struct.union([
           'string',


### PR DESCRIPTION
It is now possible to specify optional `headers` object in `devServer` config.