### PR TITLE
fix(plugin-typescript): fix typo fork-ts-cheker -> fork-ts-checker

### DIFF
--- a/plugins/typescript/index.js
+++ b/plugins/typescript/index.js
@@ -63,7 +63,7 @@ exports.apply = (
       )
 
     config
-      .plugin('fork-ts-cheker')
+      .plugin('fork-ts-checker')
       .use(require('fork-ts-checker-webpack-plugin'), [
         {
           vue: true,


### PR DESCRIPTION
I am not sure if this fix should be merged, because it may break someone's config