### PR TITLE
fix(typescript): Don't set `transpileOnly` in parallel mode

### DIFF
--- a/plugins/typescript/index.js
+++ b/plugins/typescript/index.js
@@ -49,6 +49,7 @@ exports.apply = (
       .options(
         Object.assign(
           {
+            transpileOnly: api.config.parallel ? undefined : true
             appendTsSuffixTo: ['\\.vue$'],
             // https://github.com/TypeStrong/ts-loader#happypackmode-boolean-defaultfalse
             happyPackMode: api.config.parallel

--- a/plugins/typescript/index.js
+++ b/plugins/typescript/index.js
@@ -49,7 +49,7 @@ exports.apply = (
       .options(
         Object.assign(
           {
-            transpileOnly: api.config.parallel ? undefined : true
+            transpileOnly: api.config.parallel ? undefined : true,
             appendTsSuffixTo: ['\\.vue$'],
             // https://github.com/TypeStrong/ts-loader#happypackmode-boolean-defaultfalse
             happyPackMode: api.config.parallel

--- a/plugins/typescript/index.js
+++ b/plugins/typescript/index.js
@@ -49,7 +49,6 @@ exports.apply = (
       .options(
         Object.assign(
           {
-            transpileOnly: true,
             appendTsSuffixTo: ['\\.vue$'],
             // https://github.com/TypeStrong/ts-loader#happypackmode-boolean-defaultfalse
             happyPackMode: api.config.parallel


### PR DESCRIPTION
It doesn't appear to be necessary -- for parallel builds,
happyPackMode will implicitly set it, but it can cause larger
output bundles as const enums aren't supported with that mode.