### PR TITLE
Append `poi -s` output URLs with `output.publicUrl`

### DIFF
--- a/core/dev-utils/printServeMessage.js
+++ b/core/dev-utils/printServeMessage.js
@@ -2,7 +2,14 @@ const address = require('address')
 const colors = require('./colors')
 const prettyBytes = require('./prettyBytes')
 
-module.exports = ({ host, port, expectedPort, open, isFirstBuild, publicUrl }) => {
+module.exports = ({
+  host,
+  port,
+  expectedPort,
+  open,
+  isFirstBuild,
+  publicUrl
+}) => {
   const ip = address.ip()
 
   const isUnspecifiedHost = host === '0.0.0.0' || host === '::'
@@ -10,8 +17,12 @@ module.exports = ({ host, port, expectedPort, open, isFirstBuild, publicUrl }) =
   const { heapUsed } = process.memoryUsage()
 
   console.log()
-  console.log(`Local:             http://${prettyHost}:${colors.bold(port)}${publicUrl}`)
-  console.log(`On Your Network:   http://${ip}:${colors.bold(port)}${publicUrl}`)
+  console.log(
+    `Local:             http://${prettyHost}:${colors.bold(port)}${publicUrl}`
+  )
+  console.log(
+    `On Your Network:   http://${ip}:${colors.bold(port)}${publicUrl}`
+  )
   console.log()
   if (expectedPort && expectedPort !== port) {
     console.log(colors.yellow(`> port ${expectedPort} is used!`))

--- a/core/dev-utils/printServeMessage.js
+++ b/core/dev-utils/printServeMessage.js
@@ -1,6 +1,6 @@
+const path = require('path')
 const address = require('address')
 const colors = require('./colors')
-const path = require('path')
 const prettyBytes = require('./prettyBytes')
 
 module.exports = ({

--- a/core/dev-utils/printServeMessage.js
+++ b/core/dev-utils/printServeMessage.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const url = require('url')
 const address = require('address')
 const colors = require('./colors')
 const prettyBytes = require('./prettyBytes')
@@ -18,7 +18,7 @@ module.exports = ({
   const { heapUsed } = process.memoryUsage()
 
   const urlPort = colors.bold(port)
-  const urlPath = path.join('/', publicUrl)
+  const urlPath = url.resolve('/', publicUrl).replace(/\/$/, '')
 
   console.log()
   console.log(`Local:             http://${prettyHost}:${urlPort}${urlPath}`)

--- a/core/dev-utils/printServeMessage.js
+++ b/core/dev-utils/printServeMessage.js
@@ -2,7 +2,7 @@ const address = require('address')
 const colors = require('./colors')
 const prettyBytes = require('./prettyBytes')
 
-module.exports = ({ host, port, expectedPort, open, isFirstBuild }) => {
+module.exports = ({ host, port, expectedPort, open, isFirstBuild, publicUrl }) => {
   const ip = address.ip()
 
   const isUnspecifiedHost = host === '0.0.0.0' || host === '::'
@@ -10,8 +10,8 @@ module.exports = ({ host, port, expectedPort, open, isFirstBuild }) => {
   const { heapUsed } = process.memoryUsage()
 
   console.log()
-  console.log(`Local:             http://${prettyHost}:${colors.bold(port)}`)
-  console.log(`On Your Network:   http://${ip}:${colors.bold(port)}`)
+  console.log(`Local:             http://${prettyHost}:${colors.bold(port)}${publicUrl}`)
+  console.log(`On Your Network:   http://${ip}:${colors.bold(port)}${publicUrl}`)
   console.log()
   if (expectedPort && expectedPort !== port) {
     console.log(colors.yellow(`> port ${expectedPort} is used!`))

--- a/core/dev-utils/printServeMessage.js
+++ b/core/dev-utils/printServeMessage.js
@@ -1,5 +1,6 @@
 const address = require('address')
 const colors = require('./colors')
+const path = require('path')
 const prettyBytes = require('./prettyBytes')
 
 module.exports = ({
@@ -16,13 +17,12 @@ module.exports = ({
   const prettyHost = isUnspecifiedHost ? 'localhost' : host
   const { heapUsed } = process.memoryUsage()
 
+  const urlPort = colors.bold(port)
+  const urlPath = path.join('/', publicUrl)
+
   console.log()
-  console.log(
-    `Local:             http://${prettyHost}:${colors.bold(port)}${publicUrl}`
-  )
-  console.log(
-    `On Your Network:   http://${ip}:${colors.bold(port)}${publicUrl}`
-  )
+  console.log(`Local:             http://${prettyHost}:${urlPort}${urlPath}`)
+  console.log(`On Your Network:   http://${ip}:${urlPort}${urlPath}`)
   console.log()
   if (expectedPort && expectedPort !== port) {
     console.log(colors.yellow(`> port ${expectedPort} is used!`))

--- a/core/poi/lib/plugins/serve.js
+++ b/core/poi/lib/plugins/serve.js
@@ -21,8 +21,6 @@ exports.cli = api => {
     const { host, port: _port, open } = devServer
     const port = await require('get-port')({ port: _port, host })
 
-    const { publicUrl } = Object.assign({}, api.config.output)
-
     const webpackConfig = api.createWebpackChain().toConfig()
 
     // No need to print URLs in test mode
@@ -40,7 +38,7 @@ exports.cli = api => {
               expectedPort: _port,
               open,
               isFirstBuild,
-              publicUrl
+              publicUrl: api.config.output.publicUrl
             })
 
             isFirstBuild = false

--- a/core/poi/lib/plugins/serve.js
+++ b/core/poi/lib/plugins/serve.js
@@ -21,6 +21,8 @@ exports.cli = api => {
     const { host, port: _port, open } = devServer
     const port = await require('get-port')({ port: _port, host })
 
+    const { publicUrl } = Object.assign({}, api.config.output)
+
     const webpackConfig = api.createWebpackChain().toConfig()
 
     // No need to print URLs in test mode
@@ -37,7 +39,8 @@ exports.cli = api => {
               port,
               expectedPort: _port,
               open,
-              isFirstBuild
+              isFirstBuild,
+              publicUrl
             })
 
             isFirstBuild = false

--- a/core/poi/lib/utils/validateConfig.js
+++ b/core/poi/lib/utils/validateConfig.js
@@ -190,6 +190,9 @@ module.exports = (api, config) => {
     .replace(/\/?$/, '/')
     // Remove leading ./
     .replace(/^\.\//, '')
+  if (!api.isProd && /^https?:\/\//.test(result.output.publicUrl)) {
+    result.output.publicUrl = '/'
+  }
 
   api.logger.debug('Validated config', result)
 


### PR DESCRIPTION
fix #586


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#586: Keep `poi --serve` URLs and `output.publicUrl` Consistent](https://issuehunt.io/repos/56788834/issues/586)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->