### PR TITLE
fix: keep the trailing slash of `output.publicUrl`

### DIFF
--- a/core/dev-utils/printServeMessage.js
+++ b/core/dev-utils/printServeMessage.js
@@ -20,7 +20,7 @@ module.exports = ({
   const { heapUsed } = process.memoryUsage()
 
   const urlPort = colors.bold(port)
-  const urlPath = publicUrl === '/' ? '/' : url.resolve('/', publicUrl)
+  const urlPath = publicUrl === '/' ? '' : url.resolve('/', publicUrl)
 
   console.log()
   console.log(

--- a/core/dev-utils/printServeMessage.js
+++ b/core/dev-utils/printServeMessage.js
@@ -20,7 +20,7 @@ module.exports = ({
   const { heapUsed } = process.memoryUsage()
 
   const urlPort = colors.bold(port)
-  const urlPath = url.resolve('/', publicUrl).replace(/\/$/, '')
+  const urlPath = url.resolve('/', publicUrl)
 
   console.log()
   console.log(

--- a/core/dev-utils/printServeMessage.js
+++ b/core/dev-utils/printServeMessage.js
@@ -20,7 +20,7 @@ module.exports = ({
   const { heapUsed } = process.memoryUsage()
 
   const urlPort = colors.bold(port)
-  const urlPath = url.resolve('/', publicUrl)
+  const urlPath = publicUrl === '/' ? '/' : url.resolve('/', publicUrl)
 
   console.log()
   console.log(


### PR DESCRIPTION
Because it may make 404 errors.

Example:

1. Set `output.publicUrl = /admin/` (even `/admin`)
2. Visit `http://localhost:4000/admin` => Error: `Cannot GET /admin`
3. Visit `http://localhost:4000/admin/` => Ok