### PR TITLE
fix: add regexp to allowed type of options.transpileModules

### DIFF
--- a/core/poi/lib/utils/validateConfig.js
+++ b/core/poi/lib/utils/validateConfig.js
@@ -51,7 +51,9 @@ module.exports = (api, config) => {
   const babel = struct(
     {
       jsx: 'string',
-      transpileModules: struct.optional(struct.list(['string'])),
+      transpileModules: struct.optional(
+        struct.list([struct.union(['string', 'regexp'])])
+      ),
       namedImports: struct.optional('object'),
       babelrc: struct.optional('boolean'),
       configFile: struct.optional('boolean')


### PR DESCRIPTION
accroding to this https://github.com/egoist/poi/blob/master/core/poi/lib/plugins/config-babel.js#L53-L54
regexp is allowed, AND regexp should be allowd like vue.config.js
but validations fail when regexp is passed

## use case
package manager like `cnpm` use symlink
like prettier module resolve to `node_modules/_prettier@1.19.1@prettier`

```
$ ll node_modules/prettier
lrwxr-xr-x  1 magicdawn  staff    25B 12  9 23:19 node_modules/prettier -> _prettier@1.19.1@prettier
```

regexp can be used to match this `/prettier/`