### PR TITLE
feat(eslint): Pass `loaderOptions` to `eslint-loader`

### DIFF
--- a/plugins/eslint/README.md
+++ b/plugins/eslint/README.md
@@ -31,3 +31,12 @@ module.exports = {
 ```
 
 Now ESLint will check your JS files at compile time.
+
+
+## Options
+
+### loaderOptions
+
+- Type: `any`
+
+Addtional [options](https://github.com/webpack-contrib/eslint-loader#options) for `eslint-loader`.

--- a/plugins/eslint/index.js
+++ b/plugins/eslint/index.js
@@ -1,6 +1,6 @@
 exports.name = 'eslint'
 
-exports.apply = api => {
+exports.apply = (api, options = {}) => {
   api.hook('createWebpackChain', config => {
     const { cacheIdentifier } = api.getCacheConfig('eslint-loader', {}, [
       '.eslintrc.js',
@@ -19,6 +19,7 @@ exports.apply = api => {
       .use('eslint-loader')
       .loader(require.resolve('eslint-loader'))
       .options({
+        ...options,
         cache: api.config.cache,
         cacheKey: cacheIdentifier,
         formatter: require('eslint/lib/formatters/codeframe'),

--- a/plugins/eslint/index.js
+++ b/plugins/eslint/index.js
@@ -19,11 +19,11 @@ exports.apply = (api, options = {}) => {
       .use('eslint-loader')
       .loader(require.resolve('eslint-loader'))
       .options({
-        ...options,
-        cache: api.config.cache,
-        cacheKey: cacheIdentifier,
         formatter: require('eslint/lib/formatters/codeframe'),
-        eslintPath: api.localResolve('eslint') || require.resolve('eslint')
+        eslintPath: api.localResolve('eslint') || require.resolve('eslint'),
+        ...options.loaderOptions,
+        cache: api.config.cache,
+        cacheKey: cacheIdentifier
       })
   })
 }


### PR DESCRIPTION
This PR enables `eslint-loader` to be additionally configured using `@poi/plugin-eslint` options. :tada:

/cc @dbettini