### PR TITLE
fix: transpileOnly - disable type errors in CLI

### DIFF
--- a/plugins/typescript/index.js
+++ b/plugins/typescript/index.js
@@ -6,7 +6,8 @@ exports.apply = (
     lintOnSave = true,
     configFile = 'tsconfig.json',
     babel: useBabel,
-    loaderOptions
+    loaderOptions, 
+    transpileOnly = false
   } = {}
 ) => {
   configFile = api.resolveCwd(configFile)
@@ -61,20 +62,23 @@ exports.apply = (
           require('ts-pnp')
         )
       )
-
-    config
-      .plugin('fork-ts-checker')
-      .use(require('fork-ts-checker-webpack-plugin'), [
-        {
-          vue: true,
-          tsconfig: configFile,
-          tslint:
-            lintOnSave &&
-            Boolean(api.configLoader.resolve({ files: ['tslint.json'] })),
-          formatter: 'codeframe',
-          // https://github.com/TypeStrong/ts-loader#happypackmode-boolean-defaultfalse
-          checkSyntacticErrors: api.config.parallel
-        }
-      ])
+  
+    if(!transpileOnly){
+      config
+        .plugin('fork-ts-checker')
+        .use(require('fork-ts-checker-webpack-plugin'), [
+          {
+            vue: true,
+            tsconfig: configFile,
+            tslint:
+              lintOnSave &&
+              Boolean(api.configLoader.resolve({ files: ['tslint.json'] })),
+            formatter: 'codeframe',
+            // https://github.com/TypeStrong/ts-loader#happypackmode-boolean-defaultfalse
+            checkSyntacticErrors: api.config.parallel
+          }
+        ])
+     }
+    
   })
 }


### PR DESCRIPTION
Since the editor handles most type checking, adding output for type errors to the CLI is annoying and unnecessary. 

Add a `transpileOnly` option for this plugin to allow it to be disabled.