### PR TITLE
feat(plugin-typescript): add ts-checker options

### DIFF
--- a/plugins/typescript/README.md
+++ b/plugins/typescript/README.md
@@ -67,10 +67,10 @@ The path to the TypeScript config file.
 
 - Type: `any`
 
-Addtional options for `ts-loader`.
+Addtional [options](https://github.com/TypeStrong/ts-loader#loader-options) for `ts-loader`.
 
 ### tscheckerOptions
 
 - Type: `any`
 
-Additional options for `fork-ts-checker-webpack-plugin`.
+Additional [options](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#options) for `fork-ts-checker-webpack-plugin`.

--- a/plugins/typescript/README.md
+++ b/plugins/typescript/README.md
@@ -68,3 +68,9 @@ The path to the TypeScript config file.
 - Type: `any`
 
 Addtional options for `ts-loader`.
+
+### tscheckerOptions
+
+- Type: `any`
+
+Additional options for `fork-ts-checker-webpack-plugin`.

--- a/plugins/typescript/index.js
+++ b/plugins/typescript/index.js
@@ -6,7 +6,8 @@ exports.apply = (
     lintOnSave = true,
     configFile = 'tsconfig.json',
     babel: useBabel,
-    loaderOptions
+    loaderOptions,
+    tscheckerOptions
   } = {}
 ) => {
   configFile = api.resolveCwd(configFile)
@@ -65,16 +66,21 @@ exports.apply = (
     config
       .plugin('fork-ts-checker')
       .use(require('fork-ts-checker-webpack-plugin'), [
-        {
-          vue: true,
-          tsconfig: configFile,
-          tslint:
-            lintOnSave &&
-            Boolean(api.configLoader.resolve({ files: ['tslint.json'] })),
-          formatter: 'codeframe',
-          // https://github.com/TypeStrong/ts-loader#happypackmode-boolean-defaultfalse
-          checkSyntacticErrors: api.config.parallel
-        }
+        Object.assign(
+          {
+            vue: true,
+            formatter: 'codeframe',
+            // https://github.com/TypeStrong/ts-loader#happypackmode-boolean-defaultfalse
+            checkSyntacticErrors: api.config.parallel
+          },
+          tscheckerOptions,
+          {
+            tsconfig: configFile,
+            tslint:
+              lintOnSave &&
+              Boolean(api.configLoader.resolve({ files: ['tslint.json'] }))
+          }
+        )
       ])
   })
 }


### PR DESCRIPTION
This PR adds the ability to pass options to ts-checker directly from the plugin options.

Closes #675.
