### PR TITLE
fix: HTMLWebpackPlugin name resolution in pwa-plugin

### DIFF
--- a/plugins/pwa/index.js
+++ b/plugins/pwa/index.js
@@ -53,7 +53,7 @@ exports.apply = (api, options = {}) => {
     }
 
     // Inject PWA tags in HTML
-    // Generate / tpdate manifest.json
+    // Generate / update manifest.json
     const page = api.config.pages && Object.keys(api.config.pages)[0]
     const htmlWebpackPluginName = page ? `html-page-${page}` : null
     const HtmlWebpackPlugin = config.plugins.has(htmlWebpackPluginName)

--- a/plugins/pwa/index.js
+++ b/plugins/pwa/index.js
@@ -54,8 +54,10 @@ exports.apply = (api, options = {}) => {
 
     // Inject PWA tags in HTML
     // Generate / tpdate manifest.json
-    const HtmlWebpackPlugin = config.plugins.has('html-page-0')
-      ? config.plugin('html-page-0').get('plugin')
+    const page = api.config.pages && Object.keys(api.config.pages)[0]
+    const htmlWebpackPluginName = page ? `html-page-${page}` : null
+    const HtmlWebpackPlugin = config.plugins.has(htmlWebpackPluginName)
+      ? config.plugin(htmlWebpackPluginName).get('plugin')
       : config.plugin('html').get('plugin')
     config
       .plugin('pwa-html')


### PR DESCRIPTION
This PR addresses the issue in `pwa-plugin` package when used in combination with `pages`.
The plugin would unsuccessfully try to resolve `html-page-0` plugin created for page. Following [config-html](https://github.com/egoist/poi/blob/master/core/poi/lib/plugins/config-html.js#L107) logic, this fix gets the first page name using `api.config.pages` instead.

This should resolve #759 