### PR TITLE
fix: make react refresh babel plugin optional

### DIFF
--- a/core/poi/lib/babel/preset.js
+++ b/core/poi/lib/babel/preset.js
@@ -25,11 +25,15 @@ module.exports = (
     flow,
     typescript,
     env,
-    namedImports = process.env.POI_NAMED_IMPORTS
+    namedImports = process.env.POI_NAMED_IMPORTS,
+    reactRefresh = process.env.POI_REACT_REFRESH
   } = {}
 ) => {
   if (typeof namedImports === 'string') {
     namedImports = JSON.parse(namedImports)
+  }
+  if (typeof reactRefresh === 'string') {
+    reactRefresh = reactRefresh === 'true'
   }
 
   const isVueJSX = jsx === 'vue'
@@ -40,6 +44,8 @@ module.exports = (
   // typescript transforms will only be applied to .ts .tsx files
   const isFlowEnabled = validateBoolOption('flow', flow, true)
   const isTypeScriptEnabled = validateBoolOption('typescript', typescript, true)
+
+  const isReactRefreshEnabled = isDevelopment && reactRefresh
 
   const presets = [
     [
@@ -126,7 +132,7 @@ module.exports = (
       }
     ],
     require('@babel/plugin-proposal-optional-chaining'),
-    isDevelopment && require('react-refresh/babel')
+    isReactRefreshEnabled && require('react-refresh/babel')
   ].filter(Boolean)
 
   return {

--- a/core/poi/lib/plugins/config-react-refresh.js
+++ b/core/poi/lib/plugins/config-react-refresh.js
@@ -8,7 +8,7 @@ exports.when = api => api.config.reactRefresh && api.mode === 'development'
 
 exports.apply = api => {
   api.hook('createWebpackChain', config => {
-    process.env.POI_REACT_REFRESH = Boolean(api.hasDependency('react'))
+    process.env.POI_REACT_REFRESH = api.hasDependency('react')
 
     config
       .plugin('react-refresh')

--- a/core/poi/lib/plugins/config-react-refresh.js
+++ b/core/poi/lib/plugins/config-react-refresh.js
@@ -8,19 +8,22 @@ exports.when = api => api.config.reactRefresh && api.mode === 'development'
 
 exports.apply = api => {
   api.hook('createWebpackChain', config => {
-    const reactRefresh = require('@pmmmwh/react-refresh-webpack-plugin')
-    config.plugin('react-refresh').use(reactRefresh, [
-      {
-        overlay: {
-          entry: require.resolve('@poi/dev-utils/hotDevClient'),
-          // The expected exports are slightly different from what the overlay exports,
-          // so an interop is included here to enable feedback on module-level errors.
-          module: require.resolve('@poi/dev-utils/refreshOverlayInterop'),
-          // Since we ship a custom dev client and overlay integration,
-          // the bundled socket handling logic can be eliminated.
-          sockIntegration: false
+    process.env.POI_REACT_REFRESH = true
+
+    config
+      .plugin('react-refresh')
+      .use(require('@pmmmwh/react-refresh-webpack-plugin'), [
+        {
+          overlay: {
+            entry: require.resolve('@poi/dev-utils/hotDevClient'),
+            // The expected exports are slightly different from what the overlay exports,
+            // so an interop is included here to enable feedback on module-level errors.
+            module: require.resolve('@poi/dev-utils/refreshOverlayInterop'),
+            // Since we ship a custom dev client and overlay integration,
+            // the bundled socket handling logic can be eliminated.
+            sockIntegration: false
+          }
         }
-      }
-    ])
+      ])
   })
 }

--- a/core/poi/lib/plugins/config-react-refresh.js
+++ b/core/poi/lib/plugins/config-react-refresh.js
@@ -8,7 +8,7 @@ exports.when = api => api.config.reactRefresh && api.mode === 'development'
 
 exports.apply = api => {
   api.hook('createWebpackChain', config => {
-    process.env.POI_REACT_REFRESH = true
+    process.env.POI_REACT_REFRESH = Boolean(api.hasDependency('react'))
 
     config
       .plugin('react-refresh')

--- a/core/poi/lib/utils/validateConfig.js
+++ b/core/poi/lib/utils/validateConfig.js
@@ -155,7 +155,8 @@ module.exports = (api, config) => {
     {
       cache: true,
       parallel: false,
-      publicFolder: 'public'
+      publicFolder: 'public',
+      reactRefresh: false
     }
   )
 


### PR DESCRIPTION
Remove React Refresh Babel plugin from Babel preset if `reactRefresh` option isn't set.