### PR TITLE
fix: With publicPath and historyApiFallback, manually set fallback index

### DIFF
--- a/core/poi/lib/plugins/serve.js
+++ b/core/poi/lib/plugins/serve.js
@@ -82,6 +82,13 @@ exports.cli = api => {
       }
     )
 
+    if (devServerConfig.publicPath && devServerConfig.historyApiFallback) {
+      devServerConfig.historyApiFallback = {
+        index: `${devServerConfig.publicPath}/index.html`.replace(/\/+/, '/'),
+        ...devServerConfig.historyApiFallback
+      }
+    }
+
     const existingBefore = devServerConfig.before
     devServerConfig.before = server => {
       api.hooks.invoke('beforeDevMiddlewares', server)


### PR DESCRIPTION
Fixes #763 

I'm not sure how to write a test for this, but the fix worked locally