### PR TITLE
Update package.json to include the repository

### DIFF
--- a/core/dev-utils/package.json
+++ b/core/dev-utils/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "core/dev-utils"
+  },
   "files": [
     "*.js",
     "openChrome.applescript"

--- a/core/logger/package.json
+++ b/core/logger/package.json
@@ -4,6 +4,11 @@
   "files": [
     "index.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "core/logger"
+  },
   "main": "index.js",
   "publishConfig": {
     "access": "public"

--- a/core/poi/package.json
+++ b/core/poi/package.json
@@ -7,6 +7,11 @@
   "scripts": {
     "test": "jest"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "core/poi"
+  },
   "files": [
     "lib",
     "bin",

--- a/core/test-utils/package.json
+++ b/core/test-utils/package.json
@@ -4,6 +4,11 @@
   "files": [
     "*.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "core/test-utils"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/other-packages/babel-plugin-assets-named-imports/package.json
+++ b/other-packages/babel-plugin-assets-named-imports/package.json
@@ -3,6 +3,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "other-packages/babel-plugin-assets-named-imports"
+  },
   "scripts": {
     "test": "jest --env node"
   },

--- a/other-packages/pnp-webpack-plugin/package.json
+++ b/other-packages/pnp-webpack-plugin/package.json
@@ -4,6 +4,11 @@
   "files": [
     "index.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "other-packages/pnp-webpack-plugin"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/other-packages/pwa-html-webpack-plugin/package.json
+++ b/other-packages/pwa-html-webpack-plugin/package.json
@@ -3,6 +3,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "other-packages/pwa-html-webpack-plugin"
+  },
   "version": "12.0.0",
   "main": "index.js",
   "files": [

--- a/plugins/astroturf/package.json
+++ b/plugins/astroturf/package.json
@@ -5,6 +5,11 @@
   "files": [
     "index.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/astroturf"
+  },
   "scripts": {
     "test": "jest --env node"
   },

--- a/plugins/bundle-report/package.json
+++ b/plugins/bundle-report/package.json
@@ -5,6 +5,11 @@
   "files": [
     "index.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/bundle-report"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -5,6 +5,11 @@
   "files": [
     "index.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/eslint"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/html-entry/package.json
+++ b/plugins/html-entry/package.json
@@ -5,6 +5,11 @@
   "files": [
     "lib"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/html-entry"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/karma/package.json
+++ b/plugins/karma/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/karma"
+  },
   "main": "lib/index.js",
   "scripts": {
     "example": "poi test:unit --plugin ."

--- a/plugins/puppet/package.json
+++ b/plugins/puppet/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/puppet"
+  },
   "main": "lib/index.js",
   "files": [
     "lib"

--- a/plugins/pwa/package.json
+++ b/plugins/pwa/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/pwa"
+  },
   "main": "index.js",
   "files": [
     "index.js"

--- a/plugins/typescript/package.json
+++ b/plugins/typescript/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/typescripts"
+  },
   "main": "index.js",
   "files": [
     "index.js"

--- a/plugins/vue-static/package.json
+++ b/plugins/vue-static/package.json
@@ -5,6 +5,11 @@
   "files": [
     "lib"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/egoist/poi.git",
+    "directory": "plugins/vue-static"
+  },
   "scripts": {
     "example": "poi example/index.js -so --plugin .",
     "build:example": "poi example/index.js --prod --plugin ."


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @poi/dev-utils
* @poi/logger
* poi
* @poi/test-utils
* babel-plugin-assets-named-imports
* @poi/pnp-webpack-plugin
* pwa-html-webpack-plugin
* @poi/plugin-astroturf
* @poi/plugin-bundle-report
* @poi/plugin-eslint
* @poi/plugin-html-entry
* @poi/plugin-karma
* @poi/plugin-puppet
* @poi/plugin-pwa
* @poi/plugin-typescript
* @poi/plugin-vue-static